### PR TITLE
Basic example to turn off backlight, LED and clear the screen.

### DIFF
--- a/examples/dothat/basic/off.py
+++ b/examples/dothat/basic/off.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import dothat.backlight as backlight
+import dothat.lcd as lcd
+
+"""
+This example clear the screen and turn off all LED from the Display-o-Tron HAT.
+"""
+
+# Reset the LED states and polarity
+backlight.graph_off()
+
+# Empty the screen
+lcd.clear()
+
+# Turn off the backlight
+backlight.rgb(0, 0, 0)
+


### PR DESCRIPTION
This is a frequently missing example, that should be there for all Pimoroni equipement with LED.

You play around, try all the sample code, and then you want to turn it off... so now you search for the demo that does that and try to stop it when the LED are dim or off.

This is where off.py come to the rescue for the Display-o-Tron HAT.