### PR TITLE
Fix sn3218 compat

### DIFF
--- a/library/dot3k/backlight.py
+++ b/library/dot3k/backlight.py
@@ -3,9 +3,14 @@ import math
 from sys import exit
 
 try:
-    import sn3218
+    from sn3218 import SN3218
 except ImportError:
-    exit("This library requires the sn3218 module\nInstall with: sudo pip install sn3218")
+    try:
+        import sn3218
+    except ImportError:
+        exit("This library requires the sn3218 module\nInstall with: sudo pip install sn3218")
+else:
+    sn3218 = SN3218()
 
 
 LED_R_R = 0x00

--- a/library/dothat/backlight.py
+++ b/library/dothat/backlight.py
@@ -2,9 +2,14 @@ import colorsys
 from sys import exit
 
 try:
-    import sn3218
+    from sn3218 import SN3218
 except ImportError:
-    exit("This library requires the sn3218 module\nInstall with: sudo pip install sn3218")
+    try:
+        import sn3218
+    except ImportError:
+        exit("This library requires the sn3218 module\nInstall with: sudo pip install sn3218")
+else:
+    sn3218 = SN3218()
 
 try:
     import cap1xxx

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -3,7 +3,7 @@
 import sys
 import site
 
-import mock
+from unittest import mock
 
 
 # Prompte /usr/local/lib to the front of sys.path


### PR DESCRIPTION
As mentioned in pimoroni/sn3218-python#1 this PR fixes up compatibility with v2 of the sn3218 module by conditionally importing the class and instantiating it as a replacement for the module (which is otherwise imported if the class cannot be so v1 should continue to work).