### PR TITLE
Update menu.py

### DIFF
--- a/library/dot3k/menu.py
+++ b/library/dot3k/menu.py
@@ -39,12 +39,12 @@ class StoppableThread(threading.Thread):
         self.daemon = True
 
     def start(self):
-        if not self.isAlive():
+        if not self.is_alive():
             self.stop_event.clear()
             threading.Thread.start(self)
 
     def stop(self):
-        if self.isAlive():
+        if self.is_alive():
             # set event to signal thread to terminate
             self.stop_event.set()
             # block calling thread until thread really has terminated


### PR DESCRIPTION
fixed a reference from isAlive to is_alive - there was a fix that addressed this in other places but may have missed this one; I tested on Python 3.9 and resolved the issue I had when trying to run the 'game.py' example.